### PR TITLE
add : rpc 异常传递测试

### DIFF
--- a/src/test/java/rpcconsul/MotanClientDemo.java
+++ b/src/test/java/rpcconsul/MotanClientDemo.java
@@ -17,6 +17,7 @@ package rpcconsul;
 
 import io.jboot.Jboot;
 import io.jboot.core.rpc.Jbootrpc;
+import io.jboot.exception.JbootException;
 import io.jboot.web.controller.JbootController;
 import io.jboot.web.controller.annotation.RequestMapping;
 import service.User;
@@ -59,6 +60,12 @@ public class MotanClientDemo extends JbootController {
             // 使用服务
             System.out.println("saved : " + service.saveUser(new User(i, "myname")));
             System.out.println(service.hello("海哥" + i));
+        }
+
+        try {
+            service.exception("1");
+        } catch (JbootException e) {
+            System.out.println("exception : " + e.getMessage());
         }
 
 

--- a/src/test/java/service/UserService.java
+++ b/src/test/java/service/UserService.java
@@ -24,4 +24,6 @@ public interface UserService {
     public String findUserById(String userId);
 
     public boolean saveUser(User user);
+
+    public String exception(String id);
 }

--- a/src/test/java/service/UserServiceImpl.java
+++ b/src/test/java/service/UserServiceImpl.java
@@ -17,6 +17,7 @@ package service;
 
 
 import io.jboot.Jboot;
+import io.jboot.exception.JbootException;
 
 public class UserServiceImpl implements UserService {
     @Override
@@ -39,4 +40,11 @@ public class UserServiceImpl implements UserService {
 
         return true;
     }
+
+    @Override
+    public String exception(String id) {
+        throw new JbootException(id);
+    }
+
+
 }


### PR DESCRIPTION
更新完新版以后，service 里的 异常，在controller 无法捕获到了，即使把 
+        try {
+            service.exception("1");
+        } catch (JbootException e) {
+            System.out.println("exception : " + e.getMessage());
+        }
这里的 try catch 去掉，也不会抛到 500 了，以前是没问题的，现在我在 拦截器里 自动捕获不到 service 抛出的异常了。