### PR TITLE
update : brave-opentracing version 0.23.0 not support io.opentracing 0.30.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
-            <version>0.30.0</version>
+            <version>0.31.0-RC1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
update to version 0.31.0-RC1