### PR TITLE
修复1.1.3 代码生成BaseModel后报错问题

### DIFF
--- a/src/main/java/io/jboot/codegen/model/base_model_template.jf
+++ b/src/main/java/io/jboot/codegen/model/base_model_template.jf
@@ -19,17 +19,17 @@ public abstract class #(tableMeta.baseModelName)<M extends #(tableMeta.baseModel
 
 
     @Override
-    protected String addAction() {
+    public String addAction() {
         return ACTION_ADD;
     }
 
     @Override
-    protected String deleteAction() {
+    public String deleteAction() {
         return ACTION_DELETE;
     }
 
     @Override
-    protected String updateAction() {
+    public String updateAction() {
         return ACTION_UPDATE;
     }
 


### PR DESCRIPTION
修复1.1.3 代码生成BaseModel后报错问题
1.1.2 以前没有此问题