### PR TITLE
增加dubbo qos 端口配置

### DIFF
--- a/src/main/java/io/jboot/core/rpc/dubbo/JbootDubborpc.java
+++ b/src/main/java/io/jboot/core/rpc/dubbo/JbootDubborpc.java
@@ -42,6 +42,10 @@ public class JbootDubborpc extends JbootrpcBase {
         jbootrpcConfig = Jboot.config(JbootrpcConfig.class);
         dubboConfig = Jboot.config(JbootDubborpcConfig.class);
 
+        if (StringUtils.isNotBlank(dubboConfig.getQosPort())) {
+            System.setProperty("dubbo.qos.port", String.valueOf(dubboConfig.getQosPort()));
+        }
+
         applicationConfig = new ApplicationConfig();
         applicationConfig.setName("jboot");
 

--- a/src/main/java/io/jboot/core/rpc/dubbo/JbootDubborpcConfig.java
+++ b/src/main/java/io/jboot/core/rpc/dubbo/JbootDubborpcConfig.java
@@ -28,6 +28,8 @@ public class JbootDubborpcConfig {
     private String protocolTransporter;
     private int protocolThreads = 200;
 
+    private int qosPort;
+
     public String getProtocolName() {
         return protocolName;
     }
@@ -66,5 +68,13 @@ public class JbootDubborpcConfig {
 
     public void setProtocolThreads(int protocolThreads) {
         this.protocolThreads = protocolThreads;
+    }
+
+    public int getQosPort() {
+        return qosPort;
+    }
+
+    public void setQosPort(int qosPort) {
+        this.qosPort = qosPort;
     }
 }


### PR DESCRIPTION
单机如果启动多个dubbo服务的时候，会qos端口冲突