### PR TITLE
添加配置中心按应用名称取配置文件信息

### DIFF
--- a/src/main/java/io/jboot/config/JbootConfigConfig.java
+++ b/src/main/java/io/jboot/config/JbootConfigConfig.java
@@ -48,6 +48,18 @@ public class JbootConfigConfig {
      */
     private String exclude;
 
+    /**
+     * 应用名 区分配置文件
+     */
+    private String appName="jboot";
+
+    public String getAppName() {
+        return appName;
+    }
+
+    public void setAppName(String appName) {
+        this.appName = appName;
+    }
 
     public boolean isRemoteEnable() {
         return remoteEnable;

--- a/src/main/java/io/jboot/config/JbootConfigManager.java
+++ b/src/main/java/io/jboot/config/JbootConfigManager.java
@@ -323,8 +323,10 @@ public class JbootConfigManager {
     private void initConfigRemoteReader() {
         configRemoteReader = new ConfigRemoteReader(config.getRemoteUrl(), config.getAppName(), 5) {
             @Override
-            public void onChange(String key, String oldValue, String value) {
+            public void onChange(String appName,String key, String oldValue, String value) {
 
+                if(!appName.equals(name))
+                    return;
                 /**
                  * 过滤掉系统启动参数设置
                  */

--- a/src/main/java/io/jboot/config/JbootConfigManager.java
+++ b/src/main/java/io/jboot/config/JbootConfigManager.java
@@ -291,7 +291,6 @@ public class JbootConfigManager {
             return s;
         }
 
-
         if (type == Integer.class || type == int.class) {
             return Integer.parseInt(s);
         } else if (type == Long.class || type == long.class) {
@@ -322,9 +321,10 @@ public class JbootConfigManager {
 
 
     private void initConfigRemoteReader() {
-        configRemoteReader = new ConfigRemoteReader(config.getRemoteUrl(), 5) {
+        configRemoteReader = new ConfigRemoteReader(config.getRemoteUrl(), config.getAppName(), 5) {
             @Override
             public void onChange(String key, String oldValue, String value) {
+
                 /**
                  * 过滤掉系统启动参数设置
                  */
@@ -356,6 +356,18 @@ public class JbootConfigManager {
         configRemoteReader.start();
     }
 
+    private String getKeyName(String file){
+        int index = file.indexOf('.');
+        file = file.substring(0,index);
+        index = file.indexOf('-');
+        if(index<0)
+        {
+            return "jboot";
+        }else{
+            file = file.substring(index+1);
+            return file;
+        }
+    }
 
     private void initConfigFileScanner() {
         configFileScanner = new ConfigFileScanner(config.getPath(), 5) {
@@ -363,13 +375,13 @@ public class JbootConfigManager {
             public void onChange(String action, String file) {
                 switch (action) {
                     case ConfigFileScanner.ACTION_ADD:
-                        propInfoMap.put(HashKit.md5(file), new PropInfoMap.PropInfo(new File(file)));
+                        propInfoMap.put(getKeyName(file), new PropInfoMap.PropInfo(new File(file)));
                         break;
                     case ConfigFileScanner.ACTION_DELETE:
-                        propInfoMap.remove(HashKit.md5(file));
+                        propInfoMap.remove(getKeyName(file));
                         break;
                     case ConfigFileScanner.ACTION_UPDATE:
-                        propInfoMap.put(HashKit.md5(file), new PropInfoMap.PropInfo(new File(file)));
+                        propInfoMap.put(getKeyName(file), new PropInfoMap.PropInfo(new File(file)));
                         break;
                 }
             }

--- a/src/main/java/io/jboot/config/JbootConfigManager.java
+++ b/src/main/java/io/jboot/config/JbootConfigManager.java
@@ -358,10 +358,12 @@ public class JbootConfigManager {
         configRemoteReader.start();
     }
 
-    private String getKeyName(String file){
-        int index = file.indexOf('.');
+    private static String getKeyName(String file){
+        File fileio = new File(file);
+        file = fileio.getName();
+        int index = file.lastIndexOf('.');
         file = file.substring(0,index);
-        index = file.indexOf('-');
+        index = file.lastIndexOf('-');
         if(index<0)
         {
             return "jboot";

--- a/src/main/java/io/jboot/config/client/ConfigRemoteReader.java
+++ b/src/main/java/io/jboot/config/client/ConfigRemoteReader.java
@@ -39,7 +39,7 @@ public abstract class ConfigRemoteReader {
     private Timer timer;
     private TimerTask task;
     private String url;
-    private String name;
+    protected String name;
     private int interval;
     private boolean running = false;
 
@@ -104,7 +104,7 @@ public abstract class ConfigRemoteReader {
         }
     }
 
-    public abstract void onChange(String key, String oldValue, String newValue);
+    public abstract void onChange(String appName, String key, String oldValue, String newValue);
 
 
     private int scanFailTimes = 0;
@@ -232,16 +232,16 @@ public abstract class ConfigRemoteReader {
                     String remoteValue = newPropInfo.getString(newKey);
                     remoteProperties.put(newKey.toString(), remoteValue);
                     if (localValue == null && StringUtils.isNotBlank(remoteValue)) {
-                        onChange(newKey.toString(), null, remoteValue);
+                        onChange(key, newKey.toString(), null, remoteValue);
                     } else if (!localValue.equals(remoteValue)) {
-                        onChange(newKey.toString(), localValue, remoteValue);
+                        onChange(key, newKey.toString(), localValue, remoteValue);
                     }
                 }
 
                 for (Object localKey : localPropInfo.getProperties().keySet()) {
                     if (newPropInfo.getString(localKey) == null) {
                         remoteProperties.remove(localKey);
-                        onChange(localKey.toString(), localPropInfo.getString(localKey), null);
+                        onChange(key, localKey.toString(), localPropInfo.getString(localKey), null);
                     }
                 }
             }
@@ -254,7 +254,7 @@ public abstract class ConfigRemoteReader {
             PropInfoMap.PropInfo propInfo = remotePropInfoMap.get(deleteId);
             for (Object key : propInfo.getProperties().keySet()) {
                 remoteProperties.remove(key);
-                onChange(key.toString(), propInfo.getString(key), null);
+                onChange(deleteId, key.toString(), propInfo.getString(key), null);
             }
         }
     }

--- a/src/main/java/io/jboot/config/client/ConfigRemoteReader.java
+++ b/src/main/java/io/jboot/config/client/ConfigRemoteReader.java
@@ -39,6 +39,7 @@ public abstract class ConfigRemoteReader {
     private Timer timer;
     private TimerTask task;
     private String url;
+    private String name;
     private int interval;
     private boolean running = false;
 
@@ -52,8 +53,9 @@ public abstract class ConfigRemoteReader {
 
     private final JbootHttpImpl http = new JbootHttpImpl();
 
-    public ConfigRemoteReader(String url, int interval) {
+    public ConfigRemoteReader(String url, String name, int interval) {
         this.url = url;
+        this.name = name;
         this.interval = interval;
 
         initRemoteProps();
@@ -69,7 +71,7 @@ public abstract class ConfigRemoteReader {
      * 初始化远程配置信息
      */
     private void initRemoteProps() {
-        String jsonString = httpGet(url);
+        String jsonString = httpGet(url+"/"+name);
 
         if (StringUtils.isBlank(jsonString)) {
             LogKit.error("can not get remote config info,plase check url : " + url);
@@ -221,6 +223,9 @@ public abstract class ConfigRemoteReader {
                 PropInfoMap.PropInfo newPropInfo = new PropInfoMap.PropInfo(version, properties);
                 PropInfoMap.PropInfo localPropInfo = remotePropInfoMap.get(key);
                 remotePropInfoMap.put(key, newPropInfo);
+
+                if(localPropInfo==null)
+                    continue;
 
                 for (Object newKey : newPropInfo.getProperties().keySet()) {
                     String localValue = localPropInfo.getString(newKey);

--- a/src/test/java/distributedconfig/ConfigClient.java
+++ b/src/test/java/distributedconfig/ConfigClient.java
@@ -19,11 +19,14 @@ public class ConfigClient {
 
 
         //jboot端口号配置
-        Jboot.setBootArg("jboot.server.port", "8088");
+        //Jboot.setBootArg("jboot.server.port", "8088");
 
         Jboot.setBootArg("jboot.config.remoteEnable", "true");
         Jboot.setBootArg("jboot.config.remoteUrl", "http://127.0.0.1:8080/jboot/config");
+        //Jboot.setBootArg("jboot.config.appName", "mos")
+        //不加配置中心应用名 默认使用jboot.properties配置文件
 
+        Jboot.run(args);
 
         MyConfig config = Jboot.config(MyConfig.class);
 
@@ -35,6 +38,7 @@ public class ConfigClient {
                 e.printStackTrace();
             }
         }
+
     }
 
 

--- a/src/test/java/distributedconfig/ConfigClient1.java
+++ b/src/test/java/distributedconfig/ConfigClient1.java
@@ -1,0 +1,42 @@
+package distributedconfig;
+
+import io.jboot.Jboot;
+
+/**
+ * @author Michael Yang 杨福海 （fuhai999@gmail.com）
+ * @version V1.0
+ * @package config
+ */
+public class ConfigClient {
+
+
+    /**
+     * 启动后，通过 http://127.0.0.1:8080/jboot/config 来查看数据
+     *
+     * @param args
+     */
+    public static void main(String[] args) {
+
+
+        //jboot端口号配置
+        Jboot.setBootArg("jboot.server.port", "8088");
+
+        Jboot.setBootArg("jboot.config.remoteEnable", "true");
+        Jboot.setBootArg("jboot.config.remoteUrl", "http://127.0.0.1:8080/jboot/config");
+        //Jboot.setBootArg("jboot.config.appName", "mos")
+
+        MyConfig config = Jboot.config(MyConfig.class);
+
+        for (int i = 0; i < 1000000; i++) {
+            System.out.println("------myname:" + config.getName());
+            try {
+                Thread.sleep(1000 * 2);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        Jboot.run(args);
+    }
+
+
+}

--- a/src/test/java/distributedconfig/ConfigClient1.java
+++ b/src/test/java/distributedconfig/ConfigClient1.java
@@ -7,7 +7,7 @@ import io.jboot.Jboot;
  * @version V1.0
  * @package config
  */
-public class ConfigClient {
+public class ConfigClient1 {
 
 
     /**
@@ -19,23 +19,24 @@ public class ConfigClient {
 
 
         //jboot端口号配置
-        Jboot.setBootArg("jboot.server.port", "8088");
+        //Jboot.setBootArg("jboot.server.port", "8087");
 
         Jboot.setBootArg("jboot.config.remoteEnable", "true");
         Jboot.setBootArg("jboot.config.remoteUrl", "http://127.0.0.1:8080/jboot/config");
-        //Jboot.setBootArg("jboot.config.appName", "mos")
+        Jboot.setBootArg("jboot.config.appName", "mos");
 
-        MyConfig config = Jboot.config(MyConfig.class);
+        Jboot.run(args);
+
+        MyConfig1 config = Jboot.config(MyConfig1.class);
 
         for (int i = 0; i < 1000000; i++) {
-            System.out.println("------myname:" + config.getName());
+            System.out.println("------myname1:" + config.getName());
             try {
                 Thread.sleep(1000 * 2);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
         }
-        Jboot.run(args);
     }
 
 

--- a/src/test/java/distributedconfig/ConfigServer.java
+++ b/src/test/java/distributedconfig/ConfigServer.java
@@ -18,8 +18,8 @@ public class ConfigServer {
     public static void main(String[] args) {
 
         Jboot.setBootArg("jboot.config.serverEnable", "true");
-        Jboot.setBootArg("jboot.config.path", "/Users/michael/Desktop/test");
-
+        //Jboot.setBootArg("jboot.config.path", "/Users/michael/Desktop/test");
+        Jboot.setBootArg("jboot.config.path", "C://config");//config在resources目录下 复制到C盘 即可
 
         Jboot.run(args);
     }

--- a/src/test/java/distributedconfig/MyConfig.java
+++ b/src/test/java/distributedconfig/MyConfig.java
@@ -7,7 +7,7 @@ import io.jboot.config.annotation.PropertyConfig;
  * @version V1.0
  * @Package distributedconfig
  */
-@PropertyConfig(prefix = "my")
+@PropertyConfig(prefix = "my") //多配置文件使用时 prefix一定做好区分 避免配置项混乱（JbootConfigManager的修改还未做到按应用名进行配置隔离）
 public class MyConfig {
 
     private String name = "defalutName";

--- a/src/test/java/distributedconfig/MyConfig.java
+++ b/src/test/java/distributedconfig/MyConfig.java
@@ -7,7 +7,7 @@ import io.jboot.config.annotation.PropertyConfig;
  * @version V1.0
  * @Package distributedconfig
  */
-@PropertyConfig(prefix = "my") //多配置文件使用时 prefix一定做好区分 避免配置项混乱（JbootConfigManager的修改还未做到按应用名进行配置隔离）
+@PropertyConfig(prefix = "my")
 public class MyConfig {
 
     private String name = "defalutName";

--- a/src/test/java/distributedconfig/MyConfig1.java
+++ b/src/test/java/distributedconfig/MyConfig1.java
@@ -7,8 +7,8 @@ import io.jboot.config.annotation.PropertyConfig;
  * @version V1.0
  * @Package distributedconfig
  */
-@PropertyConfig(prefix = "my")
-public class MyConfig {
+@PropertyConfig(prefix = "mos.my")//多配置文件使用时 prefix一定做好区分 避免配置项混乱（JbootConfigManager的修改还未做到按应用名进行配置隔离）
+public class MyConfig1 {
 
     private String name = "defalutName";
 

--- a/src/test/java/distributedconfig/MyConfig1.java
+++ b/src/test/java/distributedconfig/MyConfig1.java
@@ -1,0 +1,22 @@
+package distributedconfig;
+
+import io.jboot.config.annotation.PropertyConfig;
+
+/**
+ * @author Michael Yang 杨福海 （fuhai999@gmail.com）
+ * @version V1.0
+ * @Package distributedconfig
+ */
+@PropertyConfig(prefix = "my")
+public class MyConfig {
+
+    private String name = "defalutName";
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/distributedconfig/MyConfig1.java
+++ b/src/test/java/distributedconfig/MyConfig1.java
@@ -7,7 +7,7 @@ import io.jboot.config.annotation.PropertyConfig;
  * @version V1.0
  * @Package distributedconfig
  */
-@PropertyConfig(prefix = "mos.my")//多配置文件使用时 prefix一定做好区分 避免配置项混乱（JbootConfigManager的修改还未做到按应用名进行配置隔离）
+@PropertyConfig(prefix = "my")
 public class MyConfig1 {
 
     private String name = "defalutName";

--- a/src/test/resources/config/jboot-mos.properties
+++ b/src/test/resources/config/jboot-mos.properties
@@ -1,0 +1,3 @@
+jboot.mode=dev
+mos.my.name=mos1
+jboot.server.port=8087

--- a/src/test/resources/config/jboot.properties
+++ b/src/test/resources/config/jboot.properties
@@ -1,0 +1,7 @@
+#jboot.datasource.type=mysql
+#jboot.datasource.url=jdbc:mysql://localhost/jfinal_demo?characterEncoding=utf8&zeroDateTimeBehavior=convertToNull
+#jboot.datasource.user=root
+#jboot.datasource.password=root
+
+my.name=jock2
+jboot.server.port=8088


### PR DESCRIPTION
此修改并未完全做到按应用的配置分离
应用名称可以对Jboot默认启动参数起作用
自定义配置项需要严谨限定@PropertyConfig(prefix = "my")注解的prefix值，按照应用名appname.xxx的形式进行区分，如果两个app的配置存在相同key的配置项在更新时会造成配置值混乱。