### PR TITLE
修复Dev模式在Docker及K8S下资源读取死循环问题

### DIFF
--- a/src/main/java/io/jboot/app/JbootResourceLoader.java
+++ b/src/main/java/io/jboot/app/JbootResourceLoader.java
@@ -22,7 +22,6 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 


### PR DESCRIPTION
## 问题描述
在Dev模式下启动Jboot框架的程序，会获取项目的根目录，然后递归查找资源文件。在Docker及K8S环境下，根目录获取位置不准确，会导致进入系统根目录。在K8S下，K8S的系统根目录会存在动态链接问题，引起循环引用，例如：A->B->C->A->B这样的循环引用，导致CPU占用一直接近100%。

## 问题截图
1. 堆栈调用截图
![image](https://github.com/user-attachments/assets/e27819f6-3a6e-406d-8ed5-416de3f3dbf1)

2. 资源目录循环引用的截图
![image](https://github.com/user-attachments/assets/9df1ed64-7cbe-46e1-a91c-c405f7724337)

## 解决方案
1. 修改项目根目录的获取方式
2. 限制资源查找的最大递归层数为3层，防止进入死循环

