### PR TITLE
Fix Gateway header One Name has more than one Value

### DIFF
--- a/src/main/java/io/jboot/components/gateway/GatewayHttpProxy.java
+++ b/src/main/java/io/jboot/components/gateway/GatewayHttpProxy.java
@@ -193,13 +193,17 @@ public class GatewayHttpProxy {
                 if (StrUtil.isBlank(headerName) || "Content-Encoding".equalsIgnoreCase(headerName)) {
                     continue;
                 }
-
-                String headerFieldValue = conn.getHeaderField(headerName);
-                if (StrUtil.isNotBlank(headerFieldValue)) {
-                    resp.setHeader(headerName, headerFieldValue);
-                    if ("Content-Type".equalsIgnoreCase(headerName)) {
-                        isContentTypeSetted = true;
+                //出现了部分软件会返回同一个Name多个Value情况 例如gogs就是这样的
+                //所以不应该预设Name和Value都是一一对应的
+                List<String> headerFieldValues = headerFields.get(headerName);
+                if(headerFieldValues != null && !headerFieldValues.isEmpty()){
+                    for(String headerFieldValue : headerFieldValues){
+                        resp.addHeader(headerName, headerFieldValue);
+                        if ("Content-Type".equalsIgnoreCase(headerName)) {
+                            isContentTypeSetted = true;
+                        }
                     }
+
                 }
             }
         }


### PR DESCRIPTION
使用代理的时候发现例如Gogs会在Header里面出现一个Name对应多个Value的情况
之前的Gateway是默认把Name和Value做一一对应，导致Header出现了丢失